### PR TITLE
Update README for 2020-21 and .gitignore to include virtual environment venv/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ cmake-build-*/
 .vscode/
 
 .DS_Store
+
+# Virtual environments
+venv/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# sailbot-20
+# sailbot-21
 
-[![Build status](https://travis-ci.com/vt-sailbot/sailbot-20.svg?branch=master)](https://travis-ci.com/vt-sailbot/sailbot-20)
+[![Build status](https://travis-ci.com/vt-sailbot/sailbot-21.svg?branch=master)](https://travis-ci.com/vt-sailbot/sailbot-20)
 [![Coverage Status](https://coveralls.io/repos/github/vt-sailbot/sailbot-20/badge.svg?branch=master)](https://coveralls.io/github/vt-sailbot/sailbot-20?branch=master)
 [![License information](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/vt-sailbot/sailbot-20/blob/master/LICENSE)
 [![Python version](https://img.shields.io/badge/python-3.5-blue.svg)](https://www.python.org/)
 
-> The VT SailBOT team repository for the 2019-2020 school year.
+> The VT SailBOT team repository for the 2020-2021 school year.
 
 ### Architecture
 


### PR DESCRIPTION

Updated README to show proper sailbot year and added venv/ folder to .gitignore for people using virtual environments.